### PR TITLE
Fix `ddd_world_to_frustrum()` on Windows

### DIFF
--- a/objects/obj_demo/Draw_64.gml
+++ b/objects/obj_demo/Draw_64.gml
@@ -2,6 +2,6 @@ draw_surface_stretched(surf_shadowmap_near, 0, 0, 256, 256);
 draw_surface_stretched(surf_shadowmap_far, 256, 0, 256, 256);
 
 // draw a red circle at the world origin
-var point = ddd_world_to_screen(0, 0, 0, matrix_build_identity(), view_mat, proj_mat, display_get_gui_width(), display_get_gui_height());
+var point = ddd_world_to_screen(0, 0, 0, undefined, view_mat, proj_mat, display_get_gui_width(), display_get_gui_height());
 
-draw_circle_colour(point[0], display_get_gui_height() - point[1], 10, c_red, c_red, false);
+draw_circle_colour(point[0], point[1], 10, c_red, c_red, false);

--- a/scripts/ddd_world_to_frustrum/ddd_world_to_frustrum.gml
+++ b/scripts/ddd_world_to_frustrum/ddd_world_to_frustrum.gml
@@ -38,9 +38,9 @@ function ddd_world_to_frustrum(x, y, z, world_matrix = undefined, view_matrix, p
     matrix_transform_vertex(proj_matrix, result[0], result[1], result[2], result[3], result);
     
     var _w = result[3];
-    result[@ 0] /= _w;
-    result[@ 1] /= _w;
-    result[@ 2] /= _w;
-    result[@ 3]  =  1;
+    result[@ 0] /=  _w;
+    result[@ 1] /= -_w;
+    result[@ 2] /=  _w;
+    result[@ 3]  =   1;
     return result;
 }


### PR DESCRIPTION
This PR fixes the y-axis values return for `ddd_world_to_frustrum()` being inverted running on Windows. The intention is for the y-axis to be negative at the top of the screen and positive at the bottom of the screen.

This is likely to require future work to return correct values on non-Windows platforms.