### PR TITLE
Fixes world-to-screen test case

### DIFF
--- a/objects/obj_demo/Draw_64.gml
+++ b/objects/obj_demo/Draw_64.gml
@@ -3,5 +3,7 @@ draw_surface_stretched(surf_shadowmap_far, 256, 0, 256, 256);
 
 // draw a red circle at the world origin
 var point = ddd_world_to_screen(0, 0, 0, undefined, view_mat, proj_mat, display_get_gui_width(), display_get_gui_height());
-
-draw_circle_colour(point[0], point[1], 10, c_red, c_red, false);
+if ((point[2] >= 0) && (point[2] <= 1))
+{
+    draw_circle_colour(point[0], point[1], 10, c_red, c_red, false);
+}


### PR DESCRIPTION
The test case `ddd_world_to_screen()` found in `obj_demo`'s Draw GUI event will draw two red dots. One is at the world origin as expected but the other is diametrically opposite the origin along the axis from the origin to the camera's position.

This PR fixes the issue by implementing z-axis testing.